### PR TITLE
Support logging to console

### DIFF
--- a/plugins/logger/logger.js
+++ b/plugins/logger/logger.js
@@ -31,7 +31,10 @@ function useModeConsoleJson(loggerInstance, logs, levels) {
           colorize: false,
           showLevel: true,
           json: true,
-          timestamp: true
+          timestamp: true,
+          stringify: function (obj) {
+            return JSON.stringify(obj);
+          }
         })
       ],
       exitOnError: false
@@ -51,7 +54,10 @@ function useModeConsoleJson(loggerInstance, logs, levels) {
         colorize: false,
         showLevel: true,
         json: true,
-        timestamp: true
+        timestamp: true,
+        stringify: function (obj) {
+          return JSON.stringify(obj);
+        }
       })
     ],
     exitOnError: true


### PR DESCRIPTION
This PR makes it possible to switch the logging to standard out/error logging to better support deploying a search_node in a Docker-container.

The original file-based logging is used as a default so existing deployments should not be affected.

Notice: a nearly identical PR has been made against os2display/middleware: https://github.com/os2display/middleware/pull/5