### PR TITLE
Fix bug that kept us from pulling in the host configuration

### DIFF
--- a/plugins/search/search.js
+++ b/plugins/search/search.js
@@ -320,7 +320,8 @@ module.exports = function (options, imports, register) {
 
     // Connection to Elasticsearch. For more informatino about the settings
     // available see: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html
-    var hosts = JSON.parse(JSON.stringify(options.hosts));
+    // Pull in the explicit configuration of the ES host.
+    var hosts = {'hosts': JSON.parse(JSON.stringify(options.hosts))};
     var settings = JSON.parse(JSON.stringify(options.settings));
     var conf = merge(hosts, settings);
     this.es = elasticsearch.Client(conf);


### PR DESCRIPTION
Without this fix we where adding the host configuration without any key, which
caused it to be ignored. Client would then fall back to its default and connect
to localhost:9200